### PR TITLE
Use 'Goose' as the user-facing service name

### DIFF
--- a/roles/flow/files/oauth_flow/templates/base.html
+++ b/roles/flow/files/oauth_flow/templates/base.html
@@ -18,7 +18,7 @@
       <div class="card mx-auto">
         <div class="card-body">
           <img src="https://www.srcf.net/_srcf/images/logo.svg" class="logo">
-          <h5 class="logo-title">SRCF OAuth2</h5>
+          <h5 class="logo-title">SRCF Goose</h5>
         </div>
         {% block body %}{% endblock %}
       </div>


### PR DESCRIPTION
I think we should use 'Goose' as the name for all of our auth service -- both Ucam-WebAuth based and OAuth2/OIDC based.  The fact that `auth.srcf.net` and `oauth.srcf.net` operate separately is largely an implementation detail (and it might be a bit smoother if they ran from one codebase).

With this change, the screens on `oauth.srcf.net` go from looking like this:
![image](https://user-images.githubusercontent.com/1568761/230787458-3117d5e7-7f5a-4bf1-994a-da63ff70899f.png)

to this:
![image](https://user-images.githubusercontent.com/1568761/230787487-9e1524c8-a59c-43c1-a480-1ace4e34fda8.png)

Or similarly for an error screen:
![image](https://user-images.githubusercontent.com/1568761/230787571-7aef4427-c86d-49ce-892e-c827fd24ab7b.png)

The change is small but matches what `auth.srcf.net` looks like:
![image](https://user-images.githubusercontent.com/1568761/230787517-e74267c7-38f0-42a0-a889-c6d9d541ee11.png)
